### PR TITLE
Implement Twirp::Error#deconstruct_keys for pattern matching

### DIFF
--- a/lib/twirp/error.rb
+++ b/lib/twirp/error.rb
@@ -99,6 +99,11 @@ module Twirp
       to_s
     end
 
+    # Used in pattern matching
+    def deconstruct_keys(_keys)
+      to_h
+    end
+
 
   private
 

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -96,5 +96,13 @@ class TestTwirpError < Minitest::Test
     err = Twirp::Error.new(:internal, "err msg")
     assert_equal({code: :internal, msg: "err msg"}, err.to_h)
   end
+
+  def test_pattern_matching
+    err = Twirp::Error.new(:internal, "err msg", "key" => "val")
+    assert({code: :internal, msg: "err msg", meta: {"key" => "val"}} in err)
+
+    err = Twirp::Error.new(:internal, "err msg")
+    assert({code: :internal, msg: "err msg"} in err)
+  end
 end
 


### PR DESCRIPTION
Implement `Twirp::Error#deconstruct_keys` so `Twirp::Error` can be used in [pattern matching](https://docs.ruby-lang.org/en/3.0/syntax/pattern_matching_rdoc.html).

```ruby
case twirp_error
in code: :failed_precondition
  # something
else
  # something else
end
```