### PR TITLE
Add support for per-request timeout

### DIFF
--- a/lib/twirp/client.rb
+++ b/lib/twirp/client.rb
@@ -120,6 +120,10 @@ module Twirp
               r.headers[k] = v
             end
           end
+
+          if req_opts && req_opts[:timeout] && req_opts[:timeout].is_a?(Integer) && req_opts[:timeout] > 0
+            r.options.timeout = req_opts[:timeout]
+          end
         end
       end
 


### PR DESCRIPTION
Adds support for specifying a per-rpc timeout rather than being forced to use a single timeout across the whole twirp client. This is something that my team is needing so we aren't required to create entire new clients just for specific RPCs that we want to allow longer timeouts for. Since Faraday [supports this](https://lostisland.github.io/faraday/#/customization/request-options) natively, it makes sense to expose it here.

~~~ruby
client.hello({name: 'World'}, timeout: 5)
~~~