### PR TITLE
Bump `google-protobuf` to v4.27

### DIFF
--- a/test/fake_services.rb
+++ b/test/fake_services.rb
@@ -5,17 +5,8 @@ require_relative '../lib/twirp'
 
 # Protobuf messages.
 # An example of the result of the protoc ruby code generator.
-Google::Protobuf::DescriptorPool.generated_pool.build do
-  add_message "example.Size" do
-    optional :inches, :int32, 1
-  end
-  add_message "example.Hat" do
-    optional :inches, :int32, 1
-    optional :color, :string, 2
-  end
-  add_message "example.Empty" do
-  end
-end
+descriptor_data = "\n\ntest.proto\x12\x07\x65xample\"\x16\n\x04Size\x12\x0e\n\x06inches\x18\x01 \x01(\x05\"$\n\x03Hat\x12\x0e\n\x06inches\x18\x01 \x01(\x05\x12\r\n\x05\x63olor\x18\x02 \x01(\t\"\x07\n\x05\x45mptyb\x06proto3"
+Google::Protobuf::DescriptorPool.generated_pool.add_serialized_file(descriptor_data)
 
 module Example
   Size = Google::Protobuf::DescriptorPool.generated_pool.lookup("example.Size").msgclass
@@ -56,11 +47,9 @@ class EmptyClient < Twirp::Client
 end
 
 # Foo message
-Google::Protobuf::DescriptorPool.generated_pool.build do
-  add_message "Foo" do
-    optional :foo, :string, 1
-  end
-end
+descriptor_data = "\n\tfoo.proto\"\x12\n\x03\x46oo\x12\x0b\n\x03\x66oo\x18\x01 \x01(\tb\x06proto3"
+Google::Protobuf::DescriptorPool.generated_pool.add_serialized_file(descriptor_data)
+
 Foo = Google::Protobuf::DescriptorPool.generated_pool.lookup("Foo").msgclass
 
 # Foo Client

--- a/twirp.gemspec
+++ b/twirp.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = '>= 1.9'
-  spec.add_runtime_dependency 'google-protobuf', '>= 3.7.0', '< 5'
+  spec.add_runtime_dependency 'google-protobuf', '>= 3.25', '< 5.a'
   spec.add_runtime_dependency 'faraday', '< 3' # for clients
   spec.add_dependency 'rack', '>= 2.2.3' # for service server handling
 

--- a/twirp.gemspec
+++ b/twirp.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = '>= 1.9'
-  spec.add_runtime_dependency 'google-protobuf', '~> 3.0', '>= 3.7.0'
+  spec.add_runtime_dependency 'google-protobuf', '>= 3.7.0', '< 5'
   spec.add_runtime_dependency 'faraday', '< 3' # for clients
   spec.add_dependency 'rack', '>= 2.2.3' # for service server handling
 


### PR DESCRIPTION
The gem currently has a version lock on `google-protobuf` that prevents users from migrating to the `4.x` series of versions. This prevents us from upgrading our `protoc` version beyond v25, which includes needed support for service custom options, etc.

There shouldn't be any issues with supporting both `3.x` and `4.x` even though the code that `protoc` generates is not backwards compatible. All `twirp` currently cares about is that the types exist.