### PR TITLE
Support Rack 3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,8 @@ jobs:
           - "faraday-0"
           - "faraday-1"
           - "faraday-2"
+          - "rack-2"
+          - "rack-3"
 
     steps:
       - uses: actions/checkout@v4

--- a/example/Gemfile
+++ b/example/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rack"
-gem "webrick"
+gem "rack", ">= 3.0.0"
+gem "rackup"
 gem "google-protobuf", "~> 3.x"
 gem "twirp", path: "../"

--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: ..
   specs:
-    twirp (1.10.0)
+    twirp (1.12.0)
       faraday (< 3)
       google-protobuf (>= 3.25, < 5.a)
-      rack (>= 2.2.3, < 3)
+      rack (>= 2.2.3)
 
 GEM
   remote: https://rubygems.org/
@@ -14,7 +14,10 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
     google-protobuf (3.25.4)
-    rack (2.2.8.1)
+    rack (3.1.7)
+    rackup (2.0.0)
+      rack (>= 3)
+      webrick
     ruby2_keywords (0.0.5)
     webrick (1.7.0)
 
@@ -23,9 +26,9 @@ PLATFORMS
 
 DEPENDENCIES
   google-protobuf (~> 3.x)
-  rack
+  rack (>= 3.0.0)
+  rackup
   twirp!
-  webrick
 
 BUNDLED WITH
    2.4.2

--- a/example/hello_world_server.rb
+++ b/example/hello_world_server.rb
@@ -1,5 +1,5 @@
 require 'rack'
-require 'webrick'
+require 'rackup'
 
 require_relative 'hello_world/service_twirp.rb'
 
@@ -18,6 +18,4 @@ service = Example::HelloWorld::HelloWorldService.new(handler)
 
 # Mount on webserver
 path_prefix = "/twirp/" + service.full_name
-server = WEBrick::HTTPServer.new(Port: 8080)
-server.mount path_prefix, Rack::Handler::WEBrick, service
-server.start
+Rackup::Server.start app: service, Port: 8080

--- a/example_rack2/Gemfile
+++ b/example_rack2/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "rack", "< 3"
+gem "webrick"
+gem "google-protobuf", "~> 3.x"
+gem "twirp", path: "../"

--- a/example_rack2/Gemfile.lock
+++ b/example_rack2/Gemfile.lock
@@ -1,0 +1,31 @@
+PATH
+  remote: ..
+  specs:
+    twirp (1.12.0)
+      faraday (< 3)
+      google-protobuf (>= 3.25, < 5.a)
+      rack (>= 2.2.3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    faraday (2.7.2)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
+    google-protobuf (3.25.4)
+    rack (2.2.8.1)
+    ruby2_keywords (0.0.5)
+    webrick (1.7.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  google-protobuf (~> 3.x)
+  rack (< 3)
+  twirp!
+  webrick
+
+BUNDLED WITH
+   2.4.2

--- a/example_rack2/README.md
+++ b/example_rack2/README.md
@@ -1,6 +1,6 @@
 # Twirp HelloWorld Example for Rack 2
 
-This is identical to the other example, but tweaked to run under Rack 2 with `rackup`.
+This is identical to the other example, but tweaked to run under Rack 2.
 
 ### Run the example
 

--- a/example_rack2/README.md
+++ b/example_rack2/README.md
@@ -1,0 +1,50 @@
+# Twirp HelloWorld Example for Rack 2
+
+This is identical to the other example, but tweaked to run under Rack 2 with `rackup`.
+
+### Run the example
+
+To run the example, first make sure you are in the /example folder:
+```sh
+cd example
+```
+
+Install gems:
+```sh
+gem install bundler
+bundle install
+```
+
+Start the hello_world server:
+```sh
+bundle exec ruby hello_world_server.rb
+```
+
+Now you can send `curl` requests from another terminal window:
+```sh
+curl --request POST \
+  --url http://localhost:8080/twirp/example.hello_world.HelloWorld/Hello \
+  --header 'Content-Type: application/json; strict=true' \
+  --data '{"name": "World"}'
+```
+
+To send requests from Ruby code, run the hello_world client example:
+```sh
+bundle exec ruby hello_world_client.rb
+```
+
+### Run code generation
+
+Try to add a new field in `./hello_world/service.proto`, then run the generator code and see if the new field was properly added in the generated files.
+
+Make sure you have the [protobuf compiler](https://github.com/golang/protobuf) (version 3+).
+
+Install the twirp plugin with go:
+```sh
+go get -u github.com/arthurnn/twirp-ruby/protoc-gen-twirp_ruby
+```
+
+From the `/example` folder, run the generator command:
+```sh
+protoc --proto_path=. ./hello_world/service.proto --ruby_out=. --twirp_ruby_out=.
+```

--- a/example_rack2/hello_world_client.rb
+++ b/example_rack2/hello_world_client.rb
@@ -1,0 +1,1 @@
+require_relative '../example/hello_world_client.rb'

--- a/example_rack2/hello_world_server.rb
+++ b/example_rack2/hello_world_server.rb
@@ -1,0 +1,23 @@
+require 'rack'
+require 'webrick'
+
+require_relative '../example/hello_world/service_twirp.rb'
+
+# Service implementation
+class HelloWorldHandler
+  def hello(req, env)
+    puts ">> Hello #{req.name}"
+    {message: "Hello #{req.name}"}
+  end
+end
+
+# Instantiate Service
+handler = HelloWorldHandler.new()
+service = Example::HelloWorld::HelloWorldService.new(handler)
+
+
+# Mount on webserver
+path_prefix = "/twirp/" + service.full_name
+server = WEBrick::HTTPServer.new(Port: 8080)
+server.mount path_prefix, Rack::Handler::WEBrick, service
+server.start

--- a/gemfiles/rack-2.gemfile
+++ b/gemfiles/rack-2.gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gemspec path: '..'
+
+gem 'rack', '~> 2'

--- a/gemfiles/rack-3.gemfile
+++ b/gemfiles/rack-3.gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+gemspec path: '..'
+
+gem 'rack', '~> 3'

--- a/lib/twirp/service.rb
+++ b/lib/twirp/service.rb
@@ -32,7 +32,7 @@ module Twirp
       # Rack response with a Twirp::Error
       def error_response(twerr)
         status = Twirp::ERROR_CODES_TO_HTTP_STATUS[twerr.code]
-        headers = {'content-type' => Encoding::JSON} # Twirp errors are always JSON, even if the request was protobuf
+        headers = {Rack::CONTENT_TYPE => Encoding::JSON} # Twirp errors are always JSON, even if the request was protobuf
         resp_body = Encoding.encode_json(twerr.to_h)
         [status, headers, [resp_body]]
       end
@@ -181,7 +181,7 @@ module Twirp
         env[:output] = output
         @on_success.each{|hook| hook.call(env) }
 
-        headers = env[:http_response_headers].merge('content-type' => env[:content_type])
+        headers = env[:http_response_headers].merge(Rack::CONTENT_TYPE => env[:content_type])
         resp_body = Encoding.encode(output, env[:output_class], env[:content_type])
         [200, headers, [resp_body]]
 

--- a/lib/twirp/service.rb
+++ b/lib/twirp/service.rb
@@ -32,7 +32,7 @@ module Twirp
       # Rack response with a Twirp::Error
       def error_response(twerr)
         status = Twirp::ERROR_CODES_TO_HTTP_STATUS[twerr.code]
-        headers = {'Content-Type' => Encoding::JSON} # Twirp errors are always JSON, even if the request was protobuf
+        headers = {'content-type' => Encoding::JSON} # Twirp errors are always JSON, even if the request was protobuf
         resp_body = Encoding.encode_json(twerr.to_h)
         [status, headers, [resp_body]]
       end
@@ -100,7 +100,7 @@ module Twirp
       input = env[:input_class].new(input) if input.is_a? Hash
       env[:input] = input
       env[:content_type] ||= Encoding::PROTO
-      env[:http_response_headers] = {}
+      env[:http_response_headers] = defined?(Rack::Headers) ? Rack::Headers.new : {}
       call_handler(env)
     end
 
@@ -149,7 +149,7 @@ module Twirp
       end
 
       env[:input] = input
-      env[:http_response_headers] = {}
+      env[:http_response_headers] = defined?(Rack::Headers) ? Rack::Headers.new : {}
       return
     end
 
@@ -181,7 +181,7 @@ module Twirp
         env[:output] = output
         @on_success.each{|hook| hook.call(env) }
 
-        headers = env[:http_response_headers].merge('Content-Type' => env[:content_type])
+        headers = env[:http_response_headers].merge('content-type' => env[:content_type])
         resp_body = Encoding.encode(output, env[:output_class], env[:content_type])
         [200, headers, [resp_body]]
 

--- a/lib/twirp/service.rb
+++ b/lib/twirp/service.rb
@@ -138,7 +138,7 @@ module Twirp
       input = nil
       begin
         body_str = rack_request.body.read
-        rack_request.body.rewind # allow other middleware to read again (https://github.com/arthurnn/twirp-ruby/issues/50)
+        rack_request.body.rewind if rack_request.body.respond_to?(:rewind) # allow other middleware to read again (https://github.com/arthurnn/twirp-ruby/issues/50)
         input = Encoding.decode(body_str, env[:input_class], content_type)
       rescue => e
         error_msg = "Invalid request body for rpc method #{method_name.inspect} with Content-Type=#{content_type}"

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -17,7 +17,7 @@ class ServiceTest < Minitest::Test
     twerr = Twirp::Error.invalid_argument('foo')
     resp = Twirp::Service.error_response(twerr)
     assert_equal 400, resp[0]
-    assert_equal 'application/json', resp[1]['Content-Type']
+    assert_equal 'application/json', resp[1]['content-type']
     assert_equal '{"code":"invalid_argument","msg":"foo"}', resp[2][0]
   end
 
@@ -60,7 +60,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 200, status
-    assert_equal 'application/json', headers['Content-Type']
+    assert_equal 'application/json', headers['content-type']
     assert_equal({"inches" => 10, "color" => "white"}, JSON.parse(body[0]))
   end
 
@@ -69,7 +69,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 200, status
-    assert_equal 'application/json; strict=true', headers['Content-Type']
+    assert_equal 'application/json; strict=true', headers['content-type']
     assert_equal({"inches" => 0, "color" => "white"}, JSON.parse(body[0]))
   end
 
@@ -78,7 +78,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 200, status
-    assert_equal 'application/json', headers['Content-Type']
+    assert_equal 'application/json', headers['content-type']
     assert_equal({"inches" => 0, "color" => "white"}, JSON.parse(body[0]))
   end
 
@@ -87,7 +87,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 200, status
-    assert_equal 'application/protobuf', headers['Content-Type']
+    assert_equal 'application/protobuf', headers['content-type']
     assert_equal Example::Hat.new(inches: 10, color: "white"), Example::Hat.decode(body[0])
   end
 
@@ -96,7 +96,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 404, status
-    assert_equal 'application/json', headers['Content-Type']
+    assert_equal 'application/json', headers['content-type']
     assert_equal({
       "code" => 'bad_route',
       "msg"  => 'Invalid rpc method "MakeUnicorns"',
@@ -110,7 +110,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 404, status
-    assert_equal 'application/json', headers['Content-Type']
+    assert_equal 'application/json', headers['content-type']
     assert_equal({
       "code" => 'bad_route',
       "msg"  => 'HTTP request method must be POST',
@@ -124,7 +124,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 404, status
-    assert_equal 'application/json', headers['Content-Type']
+    assert_equal 'application/json', headers['content-type']
     assert_equal({
       "code" => 'bad_route',
       "msg"  => 'Unexpected Content-Type: "text/plain". Content-Type header must be one of ["application/json", "application/protobuf"]',
@@ -137,7 +137,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 404, status
-    assert_equal 'application/json', headers['Content-Type']
+    assert_equal 'application/json', headers['content-type']
     assert_equal({
       "code" => 'bad_route',
       "msg"  => 'Invalid route. Expected format: POST {BaseURL}/example.Haberdasher/{Method}',
@@ -150,7 +150,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 404, status
-    assert_equal 'application/json', headers['Content-Type'] # error responses are always JSON, even for Protobuf requests
+    assert_equal 'application/json', headers['content-type'] # error responses are always JSON, even for Protobuf requests
     assert_equal({
       "code" => 'bad_route',
       "msg"  => 'Invalid route. Expected format: POST {BaseURL}/example.Haberdasher/{Method}',
@@ -164,7 +164,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 400, status
-    assert_equal 'application/json', headers['Content-Type']
+    assert_equal 'application/json', headers['content-type']
     assert_equal({
       "code" => 'malformed',
       "msg"  => 'Invalid request body for rpc method "MakeHat" with Content-Type=application/json: ' +
@@ -179,7 +179,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 400, status
-    assert_equal 'application/json', headers['Content-Type']
+    assert_equal 'application/json', headers['content-type']
     assert_equal({
       "code" => 'malformed',
       "msg"  => 'Invalid request body for rpc method "MakeHat" with Content-Type=application/protobuf: ' +
@@ -193,7 +193,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 200, status
-    assert_equal 'application/json', headers['Content-Type']
+    assert_equal 'application/json', headers['content-type']
     assert_equal({"inches" => 10, "color" => "white"}, JSON.parse(body[0]))
   end
 
@@ -202,7 +202,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 200, status
-    assert_equal 'application/json', headers['Content-Type']
+    assert_equal 'application/json', headers['content-type']
     assert_equal({"inches" => 10, "color" => "white"}, JSON.parse(body[0]))
   end
 
@@ -211,7 +211,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 400, status
-    assert_equal 'application/json', headers['Content-Type']
+    assert_equal 'application/json', headers['content-type']
     assert_equal({
       "code" => 'malformed',
       "msg"  => 'Invalid request body for rpc method "MakeHat" with Content-Type=application/json; strict=true: ' +
@@ -289,7 +289,7 @@ class ServiceTest < Minitest::Test
     rack_env = proto_req "/example.Haberdasher/MakeHat", Example::Size.new(inches: 666)
     status, headers, body = svc.call(rack_env)
     assert_equal 400, status
-    assert_equal 'application/json', headers['Content-Type'] # error responses are always JSON, even for Protobuf requests
+    assert_equal 'application/json', headers['content-type'] # error responses are always JSON, even for Protobuf requests
     assert_equal({
       "code" => 'invalid_argument',
       "msg" => "I don't like that size",
@@ -298,7 +298,7 @@ class ServiceTest < Minitest::Test
 
   def test_handler_method_can_set_response_headers_through_the_env
     svc = Example::Haberdasher.new(HaberdasherHandler.new do |size, env|
-      env[:http_response_headers]["Cache-Control"] = "public, max-age=60"
+      env[:http_response_headers]["cache-control"] = "public, max-age=60"
       {}
     end)
 
@@ -306,8 +306,8 @@ class ServiceTest < Minitest::Test
     status, headers, body = svc.call(rack_env)
 
     assert_equal 200, status
-    assert_equal "public, max-age=60", headers["Cache-Control"] # set by the handler
-    assert_equal "application/protobuf", headers["Content-Type"] # set by Twirp::Service
+    assert_equal "public, max-age=60", headers["cache-control"] # set by the handler
+    assert_equal "application/protobuf", headers['content-type'] # set by Twirp::Service
   end
 
   def test_handler_returns_invalid_type_nil

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -17,7 +17,7 @@ class ServiceTest < Minitest::Test
     twerr = Twirp::Error.invalid_argument('foo')
     resp = Twirp::Service.error_response(twerr)
     assert_equal 400, resp[0]
-    assert_equal 'application/json', resp[1]['content-type']
+    assert_equal 'application/json', resp[1][Rack::CONTENT_TYPE]
     assert_equal '{"code":"invalid_argument","msg":"foo"}', resp[2][0]
   end
 
@@ -60,7 +60,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 200, status
-    assert_equal 'application/json', headers['content-type']
+    assert_equal 'application/json', headers[Rack::CONTENT_TYPE]
     assert_equal({"inches" => 10, "color" => "white"}, JSON.parse(body[0]))
   end
 
@@ -69,7 +69,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 200, status
-    assert_equal 'application/json; strict=true', headers['content-type']
+    assert_equal 'application/json; strict=true', headers[Rack::CONTENT_TYPE]
     assert_equal({"inches" => 0, "color" => "white"}, JSON.parse(body[0]))
   end
 
@@ -78,7 +78,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 200, status
-    assert_equal 'application/json', headers['content-type']
+    assert_equal 'application/json', headers[Rack::CONTENT_TYPE]
     assert_equal({"inches" => 0, "color" => "white"}, JSON.parse(body[0]))
   end
 
@@ -87,7 +87,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 200, status
-    assert_equal 'application/protobuf', headers['content-type']
+    assert_equal 'application/protobuf', headers[Rack::CONTENT_TYPE]
     assert_equal Example::Hat.new(inches: 10, color: "white"), Example::Hat.decode(body[0])
   end
 
@@ -96,7 +96,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 404, status
-    assert_equal 'application/json', headers['content-type']
+    assert_equal 'application/json', headers[Rack::CONTENT_TYPE]
     assert_equal({
       "code" => 'bad_route',
       "msg"  => 'Invalid rpc method "MakeUnicorns"',
@@ -110,7 +110,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 404, status
-    assert_equal 'application/json', headers['content-type']
+    assert_equal 'application/json', headers[Rack::CONTENT_TYPE]
     assert_equal({
       "code" => 'bad_route',
       "msg"  => 'HTTP request method must be POST',
@@ -124,7 +124,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 404, status
-    assert_equal 'application/json', headers['content-type']
+    assert_equal 'application/json', headers[Rack::CONTENT_TYPE]
     assert_equal({
       "code" => 'bad_route',
       "msg"  => 'Unexpected Content-Type: "text/plain". Content-Type header must be one of ["application/json", "application/protobuf"]',
@@ -137,7 +137,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 404, status
-    assert_equal 'application/json', headers['content-type']
+    assert_equal 'application/json', headers[Rack::CONTENT_TYPE]
     assert_equal({
       "code" => 'bad_route',
       "msg"  => 'Invalid route. Expected format: POST {BaseURL}/example.Haberdasher/{Method}',
@@ -150,7 +150,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 404, status
-    assert_equal 'application/json', headers['content-type'] # error responses are always JSON, even for Protobuf requests
+    assert_equal 'application/json', headers[Rack::CONTENT_TYPE] # error responses are always JSON, even for Protobuf requests
     assert_equal({
       "code" => 'bad_route',
       "msg"  => 'Invalid route. Expected format: POST {BaseURL}/example.Haberdasher/{Method}',
@@ -164,7 +164,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 400, status
-    assert_equal 'application/json', headers['content-type']
+    assert_equal 'application/json', headers[Rack::CONTENT_TYPE]
     assert_equal({
       "code" => 'malformed',
       "msg"  => 'Invalid request body for rpc method "MakeHat" with Content-Type=application/json: ' +
@@ -179,7 +179,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 400, status
-    assert_equal 'application/json', headers['content-type']
+    assert_equal 'application/json', headers[Rack::CONTENT_TYPE]
     assert_equal({
       "code" => 'malformed',
       "msg"  => 'Invalid request body for rpc method "MakeHat" with Content-Type=application/protobuf: ' +
@@ -193,7 +193,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 200, status
-    assert_equal 'application/json', headers['content-type']
+    assert_equal 'application/json', headers[Rack::CONTENT_TYPE]
     assert_equal({"inches" => 10, "color" => "white"}, JSON.parse(body[0]))
   end
 
@@ -202,7 +202,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 200, status
-    assert_equal 'application/json', headers['content-type']
+    assert_equal 'application/json', headers[Rack::CONTENT_TYPE]
     assert_equal({"inches" => 10, "color" => "white"}, JSON.parse(body[0]))
   end
 
@@ -211,7 +211,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = haberdasher_service.call(rack_env)
 
     assert_equal 400, status
-    assert_equal 'application/json', headers['content-type']
+    assert_equal 'application/json', headers[Rack::CONTENT_TYPE]
     assert_equal({
       "code" => 'malformed',
       "msg"  => 'Invalid request body for rpc method "MakeHat" with Content-Type=application/json; strict=true: ' +
@@ -289,7 +289,7 @@ class ServiceTest < Minitest::Test
     rack_env = proto_req "/example.Haberdasher/MakeHat", Example::Size.new(inches: 666)
     status, headers, body = svc.call(rack_env)
     assert_equal 400, status
-    assert_equal 'application/json', headers['content-type'] # error responses are always JSON, even for Protobuf requests
+    assert_equal 'application/json', headers[Rack::CONTENT_TYPE] # error responses are always JSON, even for Protobuf requests
     assert_equal({
       "code" => 'invalid_argument',
       "msg" => "I don't like that size",
@@ -298,7 +298,7 @@ class ServiceTest < Minitest::Test
 
   def test_handler_method_can_set_response_headers_through_the_env
     svc = Example::Haberdasher.new(HaberdasherHandler.new do |size, env|
-      env[:http_response_headers]["cache-control"] = "public, max-age=60"
+      env[:http_response_headers][Rack::CACHE_CONTROL] = "public, max-age=60"
       {}
     end)
 
@@ -306,8 +306,8 @@ class ServiceTest < Minitest::Test
     status, headers, body = svc.call(rack_env)
 
     assert_equal 200, status
-    assert_equal "public, max-age=60", headers["cache-control"] # set by the handler
-    assert_equal "application/protobuf", headers['content-type'] # set by Twirp::Service
+    assert_equal "public, max-age=60", headers[Rack::CACHE_CONTROL] # set by the handler
+    assert_equal "application/protobuf", headers[Rack::CONTENT_TYPE] # set by Twirp::Service
   end
 
   def test_handler_returns_invalid_type_nil
@@ -533,7 +533,7 @@ class ServiceTest < Minitest::Test
     status, headers, body = svc.call(rack_env)
 
     assert_equal 500, status
-    assert_equal 'application/json', headers['Content-Type']
+    assert_equal 'application/json', headers[Rack::CONTENT_TYPE]
     assert_equal({
       "code" => 'intenal',
       "msg"  => 'hook1 failed',

--- a/twirp.gemspec
+++ b/twirp.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9'
   spec.add_runtime_dependency 'google-protobuf', '>= 3.25', '< 5.a'
   spec.add_runtime_dependency 'faraday', '< 3' # for clients
-  spec.add_dependency 'rack', '>= 2.2.3', '< 3' # see https://github.com/arthurnn/twirp-ruby/issues/111
+  spec.add_dependency 'rack', '>= 2.2.3'
 
   spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'minitest', '>= 5'


### PR DESCRIPTION
Update `Service` to properly support Rack 3. 

Looks like this is all we need to do. 

* [Rewinding the body is no longer required](https://github.com/rack/rack/blob/main/UPGRADE-GUIDE.md#rackinput-is-no-longer-required-to-be-rewindable). Only `rewind` if it is rewindable. Apps can add `Rack::RewindableInput::Middleware` if they need rewindable input. 
* [Response headers must all be lower case](https://github.com/rack/rack/blob/main/UPGRADE-GUIDE.md#response-headers-must-be-lower-case). Use `Rack::Headers` as recommended (when available) to help ensure headers are lower case. 
* Updated example code for Rack 3.
* Added `example_rack2` that locks to Rack 2, but uses the code from the regular example.

Closes #111 