### PR TITLE
Better handle nil response status in client

### DIFF
--- a/lib/twirp/client.rb
+++ b/lib/twirp/client.rb
@@ -106,7 +106,7 @@ module Twirp
       end
 
       def is_http_redirect?(status)
-        status >= 300 && status <= 399
+        status && status >= 300 && status <= 399
       end
 
       def make_http_request(conn, service_full_name, rpc_method, content_type, req_opts, body)

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -58,6 +58,17 @@ class ClientTest < Minitest::Test
     assert_equal num_mthds + 1, EmptyClient.instance_methods.size # new method added
   end
 
+  def test_is_http_redirect
+    assert Twirp::Client.is_http_redirect? 300
+    assert Twirp::Client.is_http_redirect? 301
+    assert Twirp::Client.is_http_redirect? 302
+    assert Twirp::Client.is_http_redirect? 399
+
+    refute Twirp::Client.is_http_redirect? 200
+    refute Twirp::Client.is_http_redirect? 400
+    refute Twirp::Client.is_http_redirect? nil
+  end
+
 
   # Call .rpc on Protobuf client
   # ----------------------------


### PR DESCRIPTION
I've seen responses have a nil status when we're experiencing availability issues, so this prevents an "undefined method `>=' for nil" exception.